### PR TITLE
Align `config.rb` and `config.example.yml`

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -44,8 +44,8 @@ RepositoryDescription:
 
 # Remote(s)
 TargetRemote:
-  RemoteType: aptrust
-  RemoteSettings:
+  Type: aptrust
+  Settings:
     # APTrust AWS remote settings
     ReceivingBucket:
     RestoreBucket:

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -189,7 +189,7 @@ module Config
         ),
         dark_blue: DarkBlueConfig.new(
           archivematicas: (
-            data["DarkBlue"]["Archivematicas"].map do |arch_data|
+            data["DarkBlue"]["ArchivematicaInstances"].map do |arch_data|
               api_data = arch_data["API"]
               remote_data = arch_data["Remote"]
               ArchivematicaConfig.new(


### PR DESCRIPTION
This PR corrects a couple of areas where the configuration code in `config.rb` and the `config.example.yml` had diverged.