### PR TITLE
Fix time filter by ensuring microsecond precision (DBAI-23)

### DIFF
--- a/lib/archivematica.rb
+++ b/lib/archivematica.rb
@@ -87,8 +87,10 @@ module Archivematica
         "current_location" => location_uuid,
         "status" => PackageStatus::UPLOADED
       }
+      formatted_stored_date = nil
       if stored_date
-        params["stored_date__gt"] = stored_date
+        formatted_stored_date = stored_date.strftime("%Y-%m-%dT%H:%M:%S.%6N")
+        params["stored_date__gt"] = formatted_stored_date
       end
 
       package_objects = get_objects_from_pages(PACKAGE_PATH, params)
@@ -103,7 +105,7 @@ module Archivematica
       logger.info(
         "Number of packages found in location #{location_uuid} " +
         "with #{PackageStatus::UPLOADED} status" +
-        (stored_date ? " and with stored date after #{stored_date}" : "") +
+        (formatted_stored_date ? " and with stored date after #{formatted_stored_date}" : "") +
         ": #{packages.length}"
       )
       packages

--- a/run_dark_blue.rb
+++ b/run_dark_blue.rb
@@ -64,7 +64,7 @@ class DarkBlueJob
         name: arch_config.name,
         api: arch_api,
         location_uuid: api_config.location_uuid,
-        stored_date: max_updated_at&.iso8601,
+        stored_date: max_updated_at,
         object_size_limit: @object_size_limit
       ).get_package_data_objects
 


### PR DESCRIPTION
The PR aims to finish resolving DBAI-23.

During testing on the `main` branch, I discovered a bug where the latest package was repeatedly fetched. This seems to be because the `iso8601` method I was using to generate a timestamp was not using microsecond precision. I have opted to use `Time.strftime` here, since it gives me greater control and the docs remind me `DateTime` is deprecated and that's where `iso8601` is defined (looks like I could have provided a parameter there as well). I have moved the string creation inside the `ArchivematicaAPI.get_packages` method, which seems better since the formatting is a requirement of the API interaction. Open to other thoughts and ideas!

Resource(s):
- https://ruby-doc.org/3.3.0/strftime_formatting_rdoc.html
- https://www.reinhardt.io/ruby/testing/2021/05/25/stubbing-and-mocking-in-minitest.html