### PR TITLE
Make `ObjectSizeLimit` optional in preparation for deployment, introduce `PackageFilter` (DBAI-32)

### DIFF
--- a/config/config.example.yml
+++ b/config/config.example.yml
@@ -7,7 +7,8 @@ WorkingDir: "./prep"
 ExportDir: "./export"
 # Determines whether the process skips sending bag(s)
 DryRun: false
-# Objects this size or larger in bytes will not be processed.
+# Limit for the size of objects to be processed (optional)
+# This is useful for development or in environments where larger files cannot be processed.
 ObjectSizeLimit: 2000000000
 
 # Database (optional)

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -175,7 +175,7 @@ module Config
           working_dir: verify_string("WorkingDir", data["WorkingDir"]),
           export_dir: verify_string("ExportDir", data["ExportDir"]),
           dry_run: verify_boolean("DryRun", data["DryRun"]),
-          object_size_limit: verify_int("ObjectSizeLimit", data["ObjectSizeLimit"])
+          object_size_limit: data["ObjectSizeLimit"] && verify_int("ObjectSizeLimit", data["ObjectSizeLimit"])
         ),
         repository: RepositoryConfig.new(
           name: verify_string("Repository", data["Repository"]),

--- a/run_dark_blue.rb
+++ b/run_dark_blue.rb
@@ -65,7 +65,7 @@ class DarkBlueJob
         api: arch_api,
         location_uuid: api_config.location_uuid,
         stored_date: max_updated_at,
-        object_size_limit: @object_size_limit
+        **(@object_size_limit ? {package_filter: Archivematica::SizePackageFilter.new(@object_size_limit)} : {})
       ).get_package_data_objects
 
       package_data_objs.each do |package_data|


### PR DESCRIPTION
The PR aims to resolve DBAI-32. It refactors `ArchivematicaService` to accept a `PackageFilter` variant. `run_dark_blue.rb` checks to see whether a size limit is configured and passes the proper filter object if so. If not, the default `AllPackageFilter` is used.