### PR TITLE
Update `sftp`, exclude previous run artifacts from images

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 **/config.yml
 .ssh/*
+export/*
+prep/*

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem "sequel", "~> 5.77"
 
 gem "sftp",
   git: "https://github.com/mlibrary/sftp",
-  tag: "v0.3.0"
+  tag: "sftp/v0.4.2"
 
 group :test do
   gem "minitest", "~> 5.20"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 GIT
   remote: https://github.com/mlibrary/sftp
-  revision: 82fa74105a034a7dd40c4f21f86a3f9d047a90d2
-  tag: v0.3.0
+  revision: 7d9ae3ca8628699c8e5304319184835a0a843dd2
+  tag: sftp/v0.4.2
   specs:
-    sftp (0.3.0)
+    sftp (0.4.2)
 
 GEM
   remote: https://rubygems.org/


### PR DESCRIPTION
This PR bumps the `sftp` library version to get a fix resulting in the raising of errors when `sftp` commands fail. It also includes a minor change to `.dockerignore` to exclude files from `prep` and `export` from images; this will keep data out of local images and reduce the size of images. 