### PR TITLE
Allow users to re-deliver previously processed packages (DBAI-34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,13 @@ To use `verify_aptrust.rb`, override the entry command for the `dark-blue` servi
 docker compose run dark-blue ruby verify_aptrust.rb
 ```
 
-To execute a typical workflow (mentioned in the above first three steps) by simply running the command.
+You can re-deliver previously delivered packages by passing a `--packages` option to `run_dark_blue.rb`
+with a comma-separated list of package identifiers.
+```sh
+docker compose run dark-blue ruby run_dark_blue.rb --packages=some_id,some_other_id
+```
+
+To execute a typical workflow (the first three steps above), you can simply run the following command:
 ```sh
 docker compose up
 ```

--- a/lib/api_backend.rb
+++ b/lib/api_backend.rb
@@ -21,10 +21,12 @@ module APIBackend
       end
     end
 
-    def get(url, params = nil)
+    def get(url:, params: nil)
       resp = @conn.get(url, params)
       JSON.parse(resp.body)
     rescue Faraday::Error => error
+      return nil if error.is_a?(Faraday::ResourceNotFound)
+
       message = "Error occurred while interacting with REST API at #{@base_url}. " \
         "Error type: #{error.class}; " \
         "status code: #{error.response_status || "none"}; " \

--- a/lib/aptrust.rb
+++ b/lib/aptrust.rb
@@ -49,7 +49,7 @@ module APTrust
       # Modelled after https://github.com/mlibrary/heliotrope/blob/master/app/services/aptrust/service.rb
       # See also https://aptrust.github.io/registry/#/Work%20Items
       time_filter = (deposited_at - BUFFER).strftime("%Y-%m-%dT%H:%M:%S.%6N")
-      data = @backend.get("items", {
+      data = @backend.get(url: "items", params: {
         object_identifier: @object_id_prefix + bag_identifier,
         action: "Ingest",
         date_processed__gteq: time_filter,

--- a/lib/archivematica.rb
+++ b/lib/archivematica.rb
@@ -165,7 +165,6 @@ module Archivematica
       RepositoryData::RepositoryPackageData.new(
         remote_path: package.path,
         metadata: object_metadata,
-        context: @name,
         stored_time: Time.parse(package.stored_date)
       )
     end

--- a/lib/archivematica.rb
+++ b/lib/archivematica.rb
@@ -102,7 +102,7 @@ module Archivematica
       package_objects = get_objects_from_pages(url: PACKAGE_PATH, params: params)
       packages = package_objects.map { |o| create_package(o) }
       logger.info(
-        "Number of packages found in location #{location_uuid} " +
+        "Number of packages found in location #{location_uuid} " \
         "with #{PackageStatus::UPLOADED} status" +
         (formatted_stored_date ? " and with stored date after #{formatted_stored_date}" : "") +
         ": #{packages.length}"

--- a/lib/archivematica.rb
+++ b/lib/archivematica.rb
@@ -164,6 +164,7 @@ module Archivematica
       )
       RepositoryData::RepositoryPackageData.new(
         remote_path: package.path,
+        dir_name: inner_bag_dir_name,
         metadata: object_metadata,
         stored_time: Time.parse(package.stored_date)
       )

--- a/lib/archivematica.rb
+++ b/lib/archivematica.rb
@@ -84,7 +84,7 @@ module Archivematica
 
     # Returns package or nil if it doesn't exist
     def get_package(uuid)
-      package_data = @backend.get(url: PACKAGE_PATH + uuid)
+      package_data = @backend.get(url: PACKAGE_PATH + uuid + "/")
       package_data && create_package(package_data)
     end
 

--- a/lib/repository_data.rb
+++ b/lib/repository_data.rb
@@ -3,7 +3,6 @@ module RepositoryData
     "RepositoryPackageData",
     :remote_path,
     :metadata,
-    :context,
     :stored_time,
     keyword_init: true
   )

--- a/lib/repository_data.rb
+++ b/lib/repository_data.rb
@@ -2,6 +2,7 @@ module RepositoryData
   RepositoryPackageData = Struct.new(
     "RepositoryPackageData",
     :remote_path,
+    :dir_name,
     :metadata,
     :stored_time,
     keyword_init: true

--- a/run_dark_blue.rb
+++ b/run_dark_blue.rb
@@ -90,7 +90,7 @@ class DarkBlueJob
             remote_client: remote_client,
             remote_path: package_data.remote_path
           ),
-          context: package_data.context,
+          context: arch_config.name,
           validator: InnerBagValidator.new(inner_bag_dir)
         )
         courier.deliver

--- a/run_dark_blue.rb
+++ b/run_dark_blue.rb
@@ -61,14 +61,15 @@ class DarkBlueJob
 
       max_updated_at = @package_repo.get_max_updated_at_for_repository(arch_config.repository_name)
 
-      package_data_objs = Archivematica::ArchivematicaService.new(
+      arch_service = Archivematica::ArchivematicaService.new(
         name: arch_config.name,
         api: arch_api,
-        location_uuid: api_config.location_uuid,
+        location_uuid: api_config.location_uuid
+      )
+      package_data_objs = arch_service.get_package_data_objects(
         stored_date: max_updated_at,
         **(@object_size_limit ? {package_filter: Archivematica::SizePackageFilter.new(@object_size_limit)} : {})
-      ).get_package_data_objects
-
+      )
       package_data_objs.each do |package_data|
         logger.debug(package_data)
         created = @package_repo.create(

--- a/run_dark_blue.rb
+++ b/run_dark_blue.rb
@@ -78,17 +78,25 @@ class DarkBlueJob
   end
   private :deliver_package
 
-  def redeliver_package(package_identifier)
-    package = @package_repo.get_by_identifier(package_identifier)
-    raise DarkBlueError, "No repository package was found with identifier #{package_identifier}" unless package
+  def redeliver_package(identifier)
+    package = @package_repo.get_by_identifier(identifier)
+    unless package
+      message = "No repository package was found with identifier #{identifier}"
+      raise DarkBlueError, message
+    end
 
     arch_config = @arch_configs.find { |ac| ac.repository_name == package.repository_name }
-    raise DarkBlueError, "No configured Archivematica instance by name #{package.repository_name}" unless arch_config
+    unless arch_config
+      message = "No configured Archivematica instance was found " \
+        "with name #{package.repository_name}."
+      raise DarkBlueError, message
+    end
 
     arch_service = prepare_arch_service(arch_config)
     package_data = arch_service.get_package_data_object(package.identifier)
-    if !package_data
-      message = "No Archivematica package with identifier #{package.identifier} found in instance #{arch_config.name}"
+    unless package_data
+      message = "No package with identifier #{package.identifier} was found " \
+        "in #{arch_config.name} Archivematica instance."
       raise DarkBlueError, message
     end
 

--- a/run_dark_blue.rb
+++ b/run_dark_blue.rb
@@ -97,8 +97,8 @@ class DarkBlueJob
       settings: arch_config.remote.settings
     )
     deliver_package(
-      remote_client: remote_client,
       package_data: package_data,
+      remote_client: remote_client,
       context: arch_config.name
     )
   end
@@ -135,8 +135,8 @@ class DarkBlueJob
         )
       end
       deliver_package(
-        remote_client: remote_client,
         package_data: package_data,
+        remote_client: remote_client,
         context: arch_config.name
       )
     end
@@ -154,7 +154,12 @@ class DarkBlueParser
     args = DarkBlueOptions.new(options)
     opt_parser = OptionParser.new do |parser|
       parser.banner = "Usage: run_dark_blue.rb [options]"
-      parser.on("-pPACKAGES", "--packages=PACKAGES", Array, "List of comma-separated package identifiers") do |p|
+      parser.on(
+        "-pPACKAGES",
+        "--packages=PACKAGES",
+        Array,
+        "List of comma-separated package identifiers"
+      ) do |p|
         args.packages = p
       end
       parser.on("-h", "--help", "Prints this help") do

--- a/run_dark_blue.rb
+++ b/run_dark_blue.rb
@@ -64,8 +64,7 @@ class DarkBlueJob
   end
   private :prepare_arch_service
 
-  def deliver_package(remote_client:, package_data:, context:)
-    inner_bag_dir = File.basename(package_data.remote_path)
+  def deliver_package(package_data:, remote_client:, context:)
     courier = @dispatcher.dispatch(
       object_metadata: package_data.metadata,
       data_transfer: DataTransfer::RemoteClientDataTransfer.new(
@@ -73,7 +72,7 @@ class DarkBlueJob
         remote_path: package_data.remote_path
       ),
       context: context,
-      validator: InnerBagValidator.new(inner_bag_dir)
+      validator: InnerBagValidator.new(package_data.dir_name)
     )
     courier.deliver
   end

--- a/test/test_api_backend.rb
+++ b/test/test_api_backend.rb
@@ -30,13 +30,21 @@ class FaradayAPIBackendTest < Minitest::Test
       [401, {"Content-Type": "text/plain"}, "Unauthorized"]
     end
     error = assert_raises APIError do
-      @stubbed_api_backend.get("file/")
+      @stubbed_api_backend.get(url: "file/")
     end
     expected = "Error occurred while interacting with REST API at #{@base_url}. " \
       "Error type: Faraday::UnauthorizedError; " \
       "status code: 401; " \
       "body: Unauthorized"
     assert_equal expected, error.message
+  end
+
+  def test_get_returns_nil_when_resource_not_found
+    @stubs.get(@base_url + "file/") do |env|
+      [404, {"Content-Type": "text/plain"}, "Resource not found"]
+    end
+    result = @stubbed_api_backend.get(url: "file/")
+    refute(result)
   end
 
   def test_get_retries_on_timeout_to_failure
@@ -49,7 +57,7 @@ class FaradayAPIBackendTest < Minitest::Test
 
     # Final error is caught and transformed.
     error = assert_raises APIError do
-      @stubbed_api_backend.get("file/")
+      @stubbed_api_backend.get(url: "file/")
     end
     expected = "Error occurred while interacting with REST API at http://some-service.org/api/v1/. " \
       "Error type: Faraday::TimeoutError; " \
@@ -72,7 +80,7 @@ class FaradayAPIBackendTest < Minitest::Test
       end
     end
 
-    data = @stubbed_api_backend.get("file/")
+    data = @stubbed_api_backend.get(url: "file/")
     assert_equal 2, calls
     assert_equal ({}), data
   end

--- a/test/test_api_backend.rb
+++ b/test/test_api_backend.rb
@@ -44,7 +44,7 @@ class FaradayAPIBackendTest < Minitest::Test
       [404, {"Content-Type": "text/plain"}, "Resource not found"]
     end
     result = @stubbed_api_backend.get(url: "file/")
-    refute(result)
+    assert_nil result
   end
 
   def test_get_retries_on_timeout_to_failure

--- a/test/test_aptrust.rb
+++ b/test/test_aptrust.rb
@@ -58,7 +58,7 @@ class APTrustAPITest < Minitest::Test
 
   def test_get_ingest_status_failed
     data = {"results" => [{"status" => "faiLed"}]}
-    @mock_backend.expect(:get, data, ["items", @expected_params])
+    @mock_backend.expect(:get, data, url: "items", params: @expected_params)
     assert_equal "failed", @mocked_api.get_ingest_status(
       bag_identifier: @bag_identifier, deposited_at: @deposited_at
     )
@@ -67,7 +67,7 @@ class APTrustAPITest < Minitest::Test
 
   def test_get_ingest_status_cancelled
     data = {"results" => [{"status" => "Cancelled"}]}
-    @mock_backend.expect(:get, data, ["items", @expected_params])
+    @mock_backend.expect(:get, data, url: "items", params: @expected_params)
     assert_equal "cancelled", @mocked_api.get_ingest_status(
       bag_identifier: @bag_identifier, deposited_at: @deposited_at
     )
@@ -76,7 +76,7 @@ class APTrustAPITest < Minitest::Test
 
   def test_get_ingest_status_success
     data = {"results" => [{"status" => "Success", "stage" => "Cleanup"}]}
-    @mock_backend.expect(:get, data, ["items", @expected_params])
+    @mock_backend.expect(:get, data, url: "items", params: @expected_params)
     assert_equal "success", @mocked_api.get_ingest_status(
       bag_identifier: @bag_identifier, deposited_at: @deposited_at
     )
@@ -85,7 +85,7 @@ class APTrustAPITest < Minitest::Test
 
   def test_get_ingest_status_processing
     data = {"results" => [{"status" => "something_unexpected"}]}
-    @mock_backend.expect(:get, data, ["items", @expected_params])
+    @mock_backend.expect(:get, data, url: "items", params: @expected_params)
     assert_equal "processing", @mocked_api.get_ingest_status(
       bag_identifier: @bag_identifier, deposited_at: @deposited_at
     )

--- a/test/test_aptrust.rb
+++ b/test/test_aptrust.rb
@@ -49,7 +49,7 @@ class APTrustAPITest < Minitest::Test
 
   def test_get_ingest_status_not_found
     data = {"results" => nil}
-    @mock_backend.expect(:get, data, ["items", @expected_params])
+    @mock_backend.expect(:get, data, url: "items", params: @expected_params)
     assert_equal "not found", @mocked_api.get_ingest_status(
       bag_identifier: @bag_identifier, deposited_at: @deposited_at
     )

--- a/test/test_archivematica.rb
+++ b/test/test_archivematica.rb
@@ -230,7 +230,6 @@ class ArchivematicaServiceTest < Minitest::Test
           creator: "Not available",
           description: "Not available"
         ),
-        context: "test",
         stored_time: Time.utc(2024, 2, 18)
       ),
       RepositoryPackageData.new(
@@ -241,7 +240,6 @@ class ArchivematicaServiceTest < Minitest::Test
           creator: "Not available",
           description: "Not available"
         ),
-        context: "test",
         stored_time: Time.utc(2024, 2, 19)
       )
     ]

--- a/test/test_archivematica.rb
+++ b/test/test_archivematica.rb
@@ -195,12 +195,11 @@ class ArchivematicaServiceTest < Minitest::Test
     service = ArchivematicaService.new(
       name: "test",
       api: @mock_api,
-      location_uuid: @location_uuid,
-      stored_date: @stored_date
+      location_uuid: @location_uuid
     )
 
     @mock_api.expect(:get_packages, @test_packages, location_uuid: @location_uuid, stored_date: @stored_date)
-    package_data_objs = service.get_package_data_objects
+    package_data_objs = service.get_package_data_objects(stored_date: @stored_date)
     @mock_api.verify
 
     # No objects are filtered out
@@ -236,13 +235,14 @@ class ArchivematicaServiceTest < Minitest::Test
     service = ArchivematicaService.new(
       name: "test",
       api: @mock_api,
-      location_uuid: @location_uuid,
-      stored_date: @stored_date,
-      package_filter: SizePackageFilter.new(4000000)
+      location_uuid: @location_uuid
     )
 
     @mock_api.expect(:get_packages, @test_packages, location_uuid: @location_uuid, stored_date: @stored_date)
-    package_data_objs = service.get_package_data_objects
+    package_data_objs = service.get_package_data_objects(
+      stored_date: @stored_date,
+      package_filter: SizePackageFilter.new(4000000)
+    )
     @mock_api.verify
 
     # Larger object is filtered out

--- a/test/test_archivematica.rb
+++ b/test/test_archivematica.rb
@@ -224,6 +224,7 @@ class ArchivematicaServiceTest < Minitest::Test
     expected = [
       RepositoryPackageData.new(
         remote_path: first_package.path,
+        dir_name: "identifier-one-0948e2ae-eb24-4984-a71b-43bc440534d0",
         metadata: ObjectMetadata.new(
           id: first_package.uuid,
           title: "#{first_package.uuid} / identifier-one",
@@ -234,6 +235,7 @@ class ArchivematicaServiceTest < Minitest::Test
       ),
       RepositoryPackageData.new(
         remote_path: second_package.path,
+        dir_name: "identifier-two-0baa468e-dd42-49ff-ba90-5dedc30c8541",
         metadata: ObjectMetadata.new(
           id: second_package.uuid,
           title: "#{second_package.uuid} / identifier-two",

--- a/test/test_archivematica.rb
+++ b/test/test_archivematica.rb
@@ -168,7 +168,7 @@ class ArchivematicaAPITest < Minitest::Test
       stored_date: "2024-01-17T00:00:00.000000"
     )
 
-    @mock_backend.expect(:get, first_package_data, url: "file/#{first_package_data["uuid"]}")
+    @mock_backend.expect(:get, first_package_data, url: "file/#{first_package_data["uuid"]}/")
     package = @mocked_api.get_package(first_package_data["uuid"])
     @mock_backend.verify
     assert_equal expected, package
@@ -176,7 +176,7 @@ class ArchivematicaAPITest < Minitest::Test
 
   def test_get_package_when_does_not_exist
     uuid = SecureRandom.uuid
-    @mock_backend.expect(:get, nil, url: "file/#{uuid}")
+    @mock_backend.expect(:get, nil, url: "file/#{uuid}/")
     package = @mocked_api.get_package(uuid)
     @mock_backend.verify
     assert_nil package

--- a/test/test_archivematica.rb
+++ b/test/test_archivematica.rb
@@ -261,11 +261,20 @@ class ArchivematicaServiceTest < Minitest::Test
     assert_equal package_data_objs[0].metadata.id, @test_packages[0].uuid
   end
 
-  def test_get_package_data_object
+  def test_get_package_data_object_when_exists
     first_package = @test_packages[0]
     @mock_api.expect(:get_package, first_package, [first_package.uuid])
     package_data_obj = @service.get_package_data_object(first_package.uuid)
+    @mock_api.verify
     assert package_data_obj.is_a?(RepositoryPackageData)
     assert_equal first_package.path, package_data_obj.remote_path
+  end
+
+  def test_get_package_data_object_when_does_not_exist
+    uuid = SecureRandom.uuid
+    @mock_api.expect(:get_package, nil, [uuid])
+    package_data_obj = @service.get_package_data_object(uuid)
+    @mock_api.verify
+    assert_nil package_data_obj
   end
 end


### PR DESCRIPTION
This PR aims to resolve DBAI-34. It adds a way to query the Archivematica REST API for an individual item, and then refactors and adds to the Dark Blue job to allow for re-delivering of individual packages (using a command-line argument).

To Do
- [x] Add `ArchivematicaAPI.get_package`, `ArchivematicaService.get_package_data_object`
- [x] Use static UUID and paths in `test_archivematica.rb`
- [x] Make `APIBackend.get` and `ArchivematicaAPI.get_objects_from_pages` use keyword arguments 
- [x] Remove `context` from `RepositoryData::RepositoryPackageData`, and add `dir_name`
- [x] Refactor `DarkBlueJob` to include `deliver_package`, `redeliver_package`, and `redeliver_packages`
- [x] Add CLI to `run_dark_blue.rb` using `"optparse"`

Resource(s):
- https://ruby-doc.org/3.3.0/stdlibs/optparse/OptionParser.html