### PR TITLE
Prevent error/warning from AWS when running tests (DBAI-31)

### DIFF
--- a/lib/remote_client.rb
+++ b/lib/remote_client.rb
@@ -74,7 +74,7 @@ module RemoteClient
       logger.debug("Progress: #{bytes.sum} / #{totals.sum} bytes; #{percentage} %")
     end
 
-    def self.update_config(access_key_id, secret_access_key)
+    def self.update_config(access_key_id:, secret_access_key:)
       Aws.config.update(
         credentials: Aws::Credentials.new(access_key_id, secret_access_key)
       )
@@ -171,7 +171,10 @@ module RemoteClient
       case type
       when :aptrust
         aws_config = settings
-        AwsS3RemoteClient.update_config(aws_config.access_key_id, aws_config.secret_access_key)
+        AwsS3RemoteClient.update_config(
+          access_key_id: aws_config.access_key_id,
+          secret_access_key: aws_config.secret_access_key
+        )
         AwsS3RemoteClient.from_config(
           region: aws_config.region,
           bucket_name: aws_config.receiving_bucket

--- a/test/test_remote_client.rb
+++ b/test/test_remote_client.rb
@@ -114,11 +114,19 @@ class AwsS3RemoteClientTest < Minitest::Test
   def setup
     @bucket_name = "aptrust.receiving.someorg.edu"
     @region = "us-east-2"
+    @access_key_id = "some-access-key"
+    @secret_access_key = "some-secret-key"
 
+    # for testing update_config, from_config class methods
+    RemoteClient::AwsS3RemoteClient.update_config(
+      access_key_id: @access_key_id,
+      secret_access_key: @secret_access_key
+    )
     @client = RemoteClient::AwsS3RemoteClient.from_config(
       region: "us-east-2",
       bucket_name: @bucket_name
     )
+
     @role_player = @client
 
     @mock_bucket = Minitest::Mock.new
@@ -133,6 +141,12 @@ class AwsS3RemoteClientTest < Minitest::Test
   def test_from_config
     assert_equal Aws::S3::Bucket, @client.bucket.class
     assert_equal @bucket_name, @client.bucket.name
+  end
+
+  def test_update_config
+    creds = Aws.config[:credentials]
+    assert_equal @access_key_id, creds.access_key_id
+    assert_equal @secret_access_key, creds.secret_access_key
   end
 
   def test_remote_text


### PR DESCRIPTION
This PR aims to resolve [DBAI-31](https://mlit.atlassian.net/jira/software/projects/DBAI/boards/89?selectedIssue=DBAI-31).

I guess one solution to preventing the "Error retrieving instance profile credentials" message is to use the already provided `AWSS3RemoteClient.update_config` class method to set some fake credentials. I also made `update_config` use keyword arguments (recommended for two or more arguments) and added a test for `update_config` (though it was already somewhat tested in `RemoteClientFactoryTest`).