### PR TITLE
Run test suite using GitHub Actions (DBAI-11)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       mariadb:
-        image: mariadb:11
+        image: mariadb:10
         env:
           MARIADB_USER: user
           MARIADB_PASSWORD: password

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,34 @@
+name: Run Tests
+
+on: push
+
+jobs:
+  # Run tests
+  test:
+    runs-on: ubuntu-latest
+    services:
+      mariadb:
+        image: mariadb:11
+        env:
+          MARIADB_USER: user
+          MARIADB_PASSWORD: password
+          MARIADB_DATABASE: test_database
+          MARIADB_ROOT_PASSWORD: password
+        ports: ["3306:3306"]
+        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+    steps:
+      - uses: actions/checkout@v3
+      - name: Wait for MariaDB
+        run: |
+          while ! mysqladmin ping -h"127.0.0.1" -P"3306" --silent; do
+            sleep 1
+          done   
+      - name: Set up Ruby 3.2
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+      - name: Run tests
+        run: bundle exec rake test
+        env: 
+          CONFIG_PATH_YAML: "./config/config.tests.yml"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
           MARIADB_DATABASE: test_database
           MARIADB_ROOT_PASSWORD: password
         ports: ["3306:3306"]
-        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=5
     steps:
       - uses: actions/checkout@v3
       - name: Wait for MariaDB

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           for i in {1..10}
           do
-              if [[ ! $(mysqladmin ping -h"127.0.0.1" -P"3306" --silent) ]]; then
+              if [[ $(mysqladmin ping -h"127.0.0.1" -P"3306" --silent) == 0 ]]; then
                   exit 0
               else
                   sleep 3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           for i in {1..10}
           do
-              if [[ $(mysqladmin ping -h"127.0.0.1" -P"3306" --silent) == 0 ]]; then
+              if [[ $(mysqladmin ping -h"127.0.0.1" -P"3306" --silent) -eq 0 ]]; then
                   exit 0
               else
                   sleep 3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           for i in {1..10}
           do
-              if [ mysqladmin ping -h"127.0.0.1" -P"3306" --silent ]; then
+              if [[ $(mysqladmin ping -h"127.0.0.1" -P"3306" --silent) ]]; then
                   exit 0
               else
                   sleep 3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,9 +20,15 @@ jobs:
       - uses: actions/checkout@v3
       - name: Wait for MariaDB
         run: |
-          while ! mysqladmin ping -h"127.0.0.1" -P"3306" --silent; do
-            sleep 1
-          done   
+          for i in {1..10}
+          do
+              if [ mysqladmin ping -h"127.0.0.1" -P"3306" --silent ]; then
+                  exit 0
+              else
+                  sleep 3
+              fi
+          done
+          exit 1
       - name: Set up Ruby 3.2
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
               if [[ $(mysqladmin ping -h"127.0.0.1" -P"3306" --silent) ]]; then
                   exit 0
               else
-                  sleep 3
+                  sleep 10
               fi
           done
           exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,10 +22,10 @@ jobs:
         run: |
           for i in {1..10}
           do
-              if [[ $(mysqladmin ping -h"127.0.0.1" -P"3306" --silent) ]]; then
+              if [[ ! $(mysqladmin ping -h"127.0.0.1" -P"3306" --silent) ]]; then
                   exit 0
               else
-                  sleep 10
+                  sleep 3
               fi
           done
           exit 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,4 +31,4 @@ jobs:
       - name: Run tests
         run: bundle exec rake test
         env: 
-          CONFIG_PATH_YAML: "./config/config.tests.yml"
+          CONFIG_YML_PATH: "./config/config.tests.yml"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Ruby 3.2
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.2'
+          ruby-version: '3.2.3'
           bundler-cache: true
       - name: Run tests
         run: bundle exec rake test

--- a/Rakefile
+++ b/Rakefile
@@ -13,10 +13,9 @@ namespace :db do
 
     Sequel.extension :migration
 
-    config = Config::ConfigService.from_file(
-      File.join(".", "config", "config.yml")
+    db_config = Config::ConfigService.database_config_from_file(
+      ENV.fetch("CONFIG_YML_PATH", File.join(".", "config", "config.yml"))
     )
-    db_config = config.database
     if !db_config
       raise DatabaseError, "Migration failed. A database connection is not configured."
     end

--- a/config/config.tests.yml
+++ b/config/config.tests.yml
@@ -1,0 +1,8 @@
+# Configuration for GitHub Action defined in .github/workflows/tests.yaml
+
+Database:
+  Host: 127.0.0.1
+  Database: test_database
+  Port: 3306
+  User: user
+  Password: password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
         target: /run/host-services/ssh-auth.sock
     environment:
      - SSH_AUTH_SOCK=/run/host-services/ssh-auth.sock
+     - CONFIG_YML_PATH=./config/config.tests.yml
     depends_on:
       database:
         condition: "service_healthy"

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -181,6 +181,16 @@ module Config
       )
     end
 
+    def self.create_database_config(data)
+      DatabaseConfig.new(
+        host: verify_string("Host", data["Host"]),
+        database: verify_string("Database", data["Database"]),
+        port: verify_int("Port", data["Port"]),
+        user: verify_string("User", data["User"]),
+        password: verify_string("Password", data["Password"])
+      )
+    end
+
     def self.create_config(data)
       logger.debug(data)
       db_data = data.fetch("Database", nil)
@@ -197,13 +207,7 @@ module Config
           name: verify_string("Repository", data["Repository"]),
           description: verify_string("RepositoryDescription", data["RepositoryDescription"])
         ),
-        database: db_data && DatabaseConfig.new(
-          host: verify_string("Host", db_data["Host"]),
-          database: verify_string("Database", db_data["Database"]),
-          port: verify_int("Port", db_data["Port"]),
-          user: verify_string("User", db_data["User"]),
-          password: verify_string("Password", db_data["Password"])
-        ),
+        database: db_data && create_database_config(db_data),
         dark_blue: DarkBlueConfig.new(
           archivematicas: (
             data["DarkBlue"]["ArchivematicaInstances"].map do |arch_data|
@@ -232,6 +236,12 @@ module Config
           remote: create_remote_config(aptrust_data["Remote"])
         )
       )
+    end
+
+    def self.database_config_from_file(yaml_path)
+      data = read_data_from_file(yaml_path)
+      db_data = data.fetch("Database", nil)
+      db_data && create_database_config(db_data)
     end
 
     def self.from_file(yaml_path)

--- a/run_dark_blue.rb
+++ b/run_dark_blue.rb
@@ -6,7 +6,9 @@ require "sequel"
 require_relative "lib/config"
 
 SemanticLogger.add_appender(io: $stderr, formatter: :color)
-config = Config::ConfigService.from_file(File.join(".", "config", "config.yml"))
+config = Config::ConfigService.from_file(
+  ENV.fetch("CONFIG_YML_PATH", File.join(".", "config", "config.yml"))
+)
 SemanticLogger.default_level = config.settings.log_level
 
 DB = config.database && Sequel.connect(

--- a/run_example.rb
+++ b/run_example.rb
@@ -7,7 +7,9 @@ require_relative "lib/remote_client"
 
 SemanticLogger.add_appender(io: $stderr, formatter: :color)
 
-config = Config::ConfigService.from_file(File.join(".", "config", "config.yml"))
+config = Config::ConfigService.from_file(
+  ENV.fetch("CONFIG_YML_PATH", File.join(".", "config", "config.yml"))
+)
 
 SemanticLogger.default_level = config.settings.log_level
 logger = SemanticLogger["run_example"]

--- a/test/setup_db.rb
+++ b/test/setup_db.rb
@@ -6,11 +6,11 @@ require_relative "../lib/config"
 
 Sequel.extension :migration
 
-config = Config::ConfigService.from_file(
-  File.join(__dir__, "..", "config", "config.yml")
+config_yml_path = ENV.fetch("CONFIG_YML_PATH", File.join(".", "config", "config.yml"))
+db_config = Config::ConfigService.database_config_from_file(
+  File.join(__dir__, "..", config_yml_path)
 )
 
-db_config = config.database
 if !db_config
   message = "A database connection is not configured. This is required for some tests."
   raise DatabaseError, message

--- a/test/test_bag_courier.rb
+++ b/test/test_bag_courier.rb
@@ -55,7 +55,7 @@ class BagCourierTest < SequelTestCase
     @prep_path = File.join(@test_dir_path, "prep")
     @export_path = File.join(@test_dir_path, "export")
     @package_path = File.join(@test_dir_path, "package")
-    FileUtils.rm_r(@test_dir_path)
+    FileUtils.rm_r(@test_dir_path) if File.exist?(@test_dir_path)
     FileUtils.mkdir_p([@test_dir_path, @prep_path, @export_path, @package_path])
     innerbag = BagAdapter::BagAdapter.new(@package_path)
 

--- a/verify_aptrust.rb
+++ b/verify_aptrust.rb
@@ -4,7 +4,9 @@ require "sequel"
 require_relative "lib/config"
 
 SemanticLogger.add_appender(io: $stderr, formatter: :color)
-config = Config::ConfigService.from_file(File.join(".", "config", "config.yml"))
+config = Config::ConfigService.from_file(
+  ENV.fetch("CONFIG_YML_PATH", File.join(".", "config", "config.yml"))
+)
 SemanticLogger.default_level = config.settings.log_level
 
 DB = config.database && Sequel.connect(


### PR DESCRIPTION
This PR aims to resolve [DBAI-11](https://mlit.atlassian.net/jira/software/projects/DBAI/boards/89?selectedIssue=DBAI-11). It adds a GitHub Action to run the `rake` task for our tests. The action includes setup for a test MariaDB database.

There are also a few other changes worth explaining:
- I modified the entrypoint files to check an environment variable first for the configuration file, and then added a configuration file for the GitHub action to version control (nothing sensitive there). This approach will likely help us in our deployments, since we can use different file names (or locations for the file) if desired.
- Since the tests only require database configuration, I added a new `ConfigService` class method `database_config_from_file` that will only search for the `Database` key in the file and process that data. This is then used by `test/setup_db.rb` and the migration task in `Rakefile`.
- There was a bug I discovered in `test_bag_courier` where I think I failed to check for the test directory's existence before making it.