### PR TITLE
Improve `APIError` logic and handling (DBAI-43)

### DIFF
--- a/lib/archivematica.rb
+++ b/lib/archivematica.rb
@@ -84,8 +84,13 @@ module Archivematica
 
     # Returns package or nil if it doesn't exist
     def get_package(uuid)
-      package_data = @backend.get(url: PACKAGE_PATH + uuid + "/")
-      package_data && create_package(package_data)
+      begin
+        package_data = @backend.get(url: PACKAGE_PATH + uuid + "/")
+      rescue APIBackend::APIError => error
+        return nil if error.status == APIBackend::ResponseStatus::RESOURCE_NOT_FOUND
+        raise error
+      end
+      create_package(package_data)
     end
 
     def get_packages(location_uuid:, stored_date: nil)

--- a/test/test_api_backend.rb
+++ b/test/test_api_backend.rb
@@ -37,14 +37,7 @@ class FaradayAPIBackendTest < Minitest::Test
       "status code: 401; " \
       "body: Unauthorized"
     assert_equal expected, error.message
-  end
-
-  def test_get_returns_nil_when_resource_not_found
-    @stubs.get(@base_url + "file/") do |env|
-      [404, {"Content-Type": "text/plain"}, "Resource not found"]
-    end
-    result = @stubbed_api_backend.get(url: "file/")
-    assert_nil result
+    assert_equal 401, error.status
   end
 
   def test_get_retries_on_timeout_to_failure
@@ -64,6 +57,7 @@ class FaradayAPIBackendTest < Minitest::Test
       "status code: none; " \
       "body: none"
     assert_equal expected, error.message
+    assert_nil error.status
 
     assert_equal 3, calls
   end

--- a/test/test_archivematica.rb
+++ b/test/test_archivematica.rb
@@ -3,8 +3,17 @@ require "securerandom"
 require "minitest/autorun"
 require "minitest/pride"
 
+require_relative "../lib/api_backend"
 require_relative "../lib/archivematica"
 require_relative "../lib/repository_data"
+
+class FakeBackend
+  def get(uuid)
+    raise APIBackend::APIError.new(
+      message: "Error message here", status: APIBackend::ResponseStatus::RESOURCE_NOT_FOUND
+    )
+  end
+end
 
 class ArchivematicaAPITest < Minitest::Test
   include Archivematica
@@ -175,10 +184,9 @@ class ArchivematicaAPITest < Minitest::Test
   end
 
   def test_get_package_when_does_not_exist
+    api = ArchivematicaAPI.new(api_backend: FakeBackend.new)
     uuid = SecureRandom.uuid
-    @mock_backend.expect(:get, nil, url: "file/#{uuid}/")
-    package = @mocked_api.get_package(uuid)
-    @mock_backend.verify
+    package = api.get_package(uuid)
     assert_nil package
   end
 end


### PR DESCRIPTION
This PR aims to partially resolve DBAI-43. It moves responsibility for handling `404` errors from the `APIBackend` up to the `ArchivematicaAPI`, since not all `get` calls will want to return `nil` in that case. I added a `status` method to `APIError` and a `ResponseStatus` module so that higher-level classes can use those to handle cases as they see fit.