### PR TITLE
Fix missed usage of `get_value` without key (DBAI-18)

### DIFF
--- a/lib/config.rb
+++ b/lib/config.rb
@@ -238,7 +238,7 @@ module Config
             )
           when :file_system
             FileSystemRemoteConfig.new(
-              remote_path: settings.get_value("FILE_SYSTEM_REMOTE_PATH")
+              remote_path: settings.get_value(key: "FILE_SYSTEM_REMOTE_PATH")
             )
           when :sftp
             SftpRemoteConfig.new(


### PR DESCRIPTION
This PR fixes a bug in `ConfigService` that snuck into PR #38.