### PR TITLE
Refactor `Dispatcher` (DBAI-42)

### DIFF
--- a/example.env
+++ b/example.env
@@ -1,21 +1,24 @@
 # Bag Courier Environment Variables Example/Template
 
+# Directory paths should be absolute or relative to root
+
 # Settings
 # One of info, debug, error, warn, trace, fatal
 SETTINGS_LOG_LEVEL=debug
-# Directory paths should be absolute or relative to root
-SETTINGS_WORKING_DIR=./prep
-SETTINGS_EXPORT_DIR=./export
-SETTINGS_RESTORE_DIR=./restore
-# Determines whether to remove tar files from export, either true or false (should be true in production)
-SETTINGS_REMOVE_EXPORT=true
-# Determines whether the process skips sending bag(s)
-SETTINGS_DRY_RUN=false
+
 # Limit for the size (in bytes) of objects to be processed (optional)
 # This is useful for development or in environments where larger files cannot be processed.
 SETTINGS_OBJECT_SIZE_LIMIT=
 # Number of objects per repository (e.g. Archivematica instance) to process at once (optional)
 SETTINGS_NUM_OBJECTS_PER_REPOSITORY=
+SETTINGS_RESTORE_DIR=./restore
+# Workflow
+SETTINGS_WORKFLOW_WORKING_DIR=./prep
+SETTINGS_WORKFLOW_EXPORT_DIR=./export
+# Determines whether to remove tar files from export, either true or false (should be true in production)
+SETTINGS_WORKFLOW_REMOVE_EXPORT=true
+# Determines whether the process skips sending bag(s)
+SETTINGS_WORKFLOW_DRY_RUN=false
 
 # Repository
 # Name that will be used for the repository at the beginning of bag identifiers

--- a/example.env
+++ b/example.env
@@ -5,7 +5,6 @@
 # Settings
 # One of info, debug, error, warn, trace, fatal
 SETTINGS_LOG_LEVEL=debug
-
 # Limit for the size (in bytes) of objects to be processed (optional)
 # This is useful for development or in environments where larger files cannot be processed.
 SETTINGS_OBJECT_SIZE_LIMIT=

--- a/lib/bag_courier.rb
+++ b/lib/bag_courier.rb
@@ -26,7 +26,7 @@ module BagCourier
 
     EXT_TAR = ".tar"
 
-    attr_reader :bag_id, :status_event_repo
+    attr_reader :bag_id, :bag_info, :tags, :status_event_repo
 
     def initialize(
       bag_id:,

--- a/lib/bag_courier.rb
+++ b/lib/bag_courier.rb
@@ -33,13 +33,13 @@ module BagCourier
       bag_info:,
       tags:,
       data_transfer:,
+      validator:,
       target_client:,
+      status_event_repo:,
       working_dir:,
       export_dir:,
-      remove_export:,
       dry_run:,
-      status_event_repo:,
-      validator:
+      remove_export:
     )
       @bag_id = bag_id
       @bag_info = bag_info

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -148,18 +148,18 @@ module Config
     keyword_init: true
   )
 
-  RemoteConfig = Struct.new(
-    "RemoteConfig",
-    :type,
-    :settings,
-    keyword_init: true
-  )
-
   SftpRemoteConfig = Struct.new(
     "SftpRemoteConfig",
     :host,
     :user,
     :key_path,
+    keyword_init: true
+  )
+
+  RemoteConfig = Struct.new(
+    "RemoteConfig",
+    :type,
+    :settings,
     keyword_init: true
   )
 

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -287,6 +287,7 @@ module Config
 
     def self.create_config(data)
       data = CheckableData.new(data)
+      settings_workflow_data = data.get_subset_by_key_stem("SETTINGS_WORKFLOW_")
       db_data = data.get_subset_by_key_stem("DATABASE_")
 
       arch_configs = []
@@ -306,10 +307,10 @@ module Config
           )&.to_i,
           restore_dir: data.get_value(key: "SETTINGS_RESTORE_DIR"),
           workflow: WorkflowConfig.new(
-            working_dir: data.get_value(key: "SETTINGS_WORKING_DIR"),
-            export_dir: data.get_value(key: "SETTINGS_EXPORT_DIR"),
-            dry_run: data.get_value(key: "SETTINGS_DRY_RUN", checks: [BOOLEAN_CHECK]) == "true",
-            remove_export: data.get_value(key: "SETTINGS_REMOVE_EXPORT", checks: [BOOLEAN_CHECK]) == "true"
+            working_dir: settings_workflow_data.get_value(key: "WORKING_DIR"),
+            export_dir: settings_workflow_data.get_value(key: "EXPORT_DIR"),
+            dry_run: settings_workflow_data.get_value(key: "DRY_RUN", checks: [BOOLEAN_CHECK]) == "true",
+            remove_export: settings_workflow_data.get_value(key: "REMOVE_EXPORT", checks: [BOOLEAN_CHECK]) == "true"
           )
         ),
         repository: RepositoryConfig.new(

--- a/lib/config.rb
+++ b/lib/config.rb
@@ -101,16 +101,22 @@ module Config
     end
   end
 
+  WorkflowConfig = Struct.new(
+    "WorkflowConfig",
+    :working_dir,
+    :export_dir,
+    :remove_export,
+    :dry_run,
+    keyword_init: true
+  )
+
   SettingsConfig = Struct.new(
     "SettingsConfig",
     :log_level,
-    :working_dir,
-    :export_dir,
-    :restore_dir,
-    :remove_export,
-    :dry_run,
     :object_size_limit,
     :num_objects_per_repo,
+    :restore_dir,
+    :workflow,
     keyword_init: true
   )
 
@@ -292,17 +298,19 @@ module Config
       Config.new(
         settings: SettingsConfig.new(
           log_level: data.get_value(key: "SETTINGS_LOG_LEVEL", checks: [LOG_LEVEL_CHECK]).to_sym,
-          working_dir: data.get_value(key: "SETTINGS_WORKING_DIR"),
-          export_dir: data.get_value(key: "SETTINGS_EXPORT_DIR"),
-          restore_dir: data.get_value(key: "SETTINGS_RESTORE_DIR"),
-          dry_run: data.get_value(key: "SETTINGS_DRY_RUN", checks: [BOOLEAN_CHECK]) == "true",
-          remove_export: data.get_value(key: "SETTINGS_REMOVE_EXPORT", checks: [BOOLEAN_CHECK]) == "true",
           object_size_limit: data.get_value(
             key: "SETTINGS_OBJECT_SIZE_LIMIT", checks: [IntegerCheck.new], optional: true
           )&.to_i,
           num_objects_per_repo: data.get_value(
             key: "SETTINGS_NUM_OBJECTS_PER_REPOSITORY", checks: [IntegerCheck.new], optional: true
-          )&.to_i
+          )&.to_i,
+          restore_dir: data.get_value(key: "SETTINGS_RESTORE_DIR"),
+          workflow: WorkflowConfig.new(
+            working_dir: data.get_value(key: "SETTINGS_WORKING_DIR"),
+            export_dir: data.get_value(key: "SETTINGS_EXPORT_DIR"),
+            dry_run: data.get_value(key: "SETTINGS_DRY_RUN", checks: [BOOLEAN_CHECK]) == "true",
+            remove_export: data.get_value(key: "SETTINGS_REMOVE_EXPORT", checks: [BOOLEAN_CHECK]) == "true"
+          )
         ),
         repository: RepositoryConfig.new(
           name: data.get_value(key: "REPOSITORY_NAME"),

--- a/lib/dispatcher.rb
+++ b/lib/dispatcher.rb
@@ -24,11 +24,13 @@ module Dispatcher
       settings:,
       repository:,
       target_client:,
+      context: nil,
       status_event_repo: StatusEventRepository::StatusEventInMemoryRepository.new,
       bag_repo: BagRepository::BagInMemoryRepository.new
     )
       @settings = settings
       @repository = repository
+      @context = context
       @target_client = target_client
       @status_event_repo = status_event_repo
       @bag_repo = bag_repo
@@ -37,14 +39,13 @@ module Dispatcher
     def dispatch(
       object_metadata:,
       data_transfer:,
-      context: nil,
       validator: nil,
       extra_bag_info_data: nil
     )
       bag_id = BagCourier::BagId.new(
         repository: @repository.name,
         object_id: object_metadata.id,
-        context: context
+        context: @context
       )
       bag_info = BagTag::BagInfoBagTag.new(
         identifier: object_metadata.id,

--- a/lib/dispatcher.rb
+++ b/lib/dispatcher.rb
@@ -72,14 +72,14 @@ module Dispatcher
         bag_id: bag_id,
         bag_info: bag_info,
         tags: tags,
-        target_client: @target_client,
         data_transfer: data_transfer,
+        validator: validator,
+        target_client: @target_client,
         status_event_repo: @status_event_repo,
         working_dir: @settings.working_dir,
         export_dir: @settings.export_dir,
-        remove_export: @settings.remove_export,
         dry_run: @settings.dry_run,
-        validator: validator
+        remove_export: @settings.remove_export
       )
     end
   end

--- a/lib/dispatcher.rb
+++ b/lib/dispatcher.rb
@@ -25,12 +25,14 @@ module Dispatcher
       repository:,
       target_client:,
       context: nil,
+      extra_bag_info_data: nil,
       status_event_repo: StatusEventRepository::StatusEventInMemoryRepository.new,
       bag_repo: BagRepository::BagInMemoryRepository.new
     )
       @settings = settings
       @repository = repository
       @context = context
+      @extra_bag_info_data = extra_bag_info_data
       @target_client = target_client
       @status_event_repo = status_event_repo
       @bag_repo = bag_repo
@@ -39,8 +41,7 @@ module Dispatcher
     def dispatch(
       object_metadata:,
       data_transfer:,
-      validator: nil,
-      extra_bag_info_data: nil
+      validator: nil
     )
       bag_id = BagCourier::BagId.new(
         repository: @repository.name,
@@ -50,7 +51,7 @@ module Dispatcher
       bag_info = BagTag::BagInfoBagTag.new(
         identifier: object_metadata.id,
         description: @repository.description,
-        extra_data: extra_bag_info_data
+        extra_data: @extra_bag_info_data
       )
       tags = [
         BagTag::AptrustInfoBagTag.new(

--- a/run_dark_blue.rb
+++ b/run_dark_blue.rb
@@ -41,7 +41,7 @@ class DarkBlueJob
 
   def create_dispatcher(context:, extra_bag_info_data:)
     Dispatcher::APTrustDispatcher.new(
-      settings: @settings_config,
+      settings: @settings_config.workflow,
       repository: @repository_config,
       target_client: RemoteClient::RemoteClientFactory.from_config(
         type: @aptrust_config.remote.type,

--- a/run_dark_blue.rb
+++ b/run_dark_blue.rb
@@ -148,13 +148,15 @@ class DarkBlueJob
     )
 
     max_updated_at = @package_repo.get_max_updated_at_for_repository(arch_config.repository_name)
+    object_size_limit = @settings_config.object_size_limit
+    num_objects_per_repo = @settings_config.num_objects_per_repo
     package_data_objs = arch_service.get_package_data_objects(
       stored_date: max_updated_at,
-      **(@object_size_limit ? {package_filter: Archivematica::SizePackageFilter.new(@object_size_limit)} : {})
+      **(object_size_limit ? {package_filter: Archivematica::SizePackageFilter.new(object_size_limit)} : {})
     )
 
-    if @settings.num_objects_per_repo && package_data_objs.length > @settings.num_objects_per_repo
-      package_data_objs = package_data_objs.take(@settings.num_objects_per_repo)
+    if num_objects_per_repo && package_data_objs.length > num_objects_per_repo
+      package_data_objs = package_data_objs.take(num_objects_per_repo)
     end
 
     package_data_objs.each do |package_data|

--- a/test/test_dispatcher.rb
+++ b/test/test_dispatcher.rb
@@ -1,0 +1,85 @@
+require "minitest/autorun"
+require "minitest/pride"
+
+require_relative "setup_db"
+require_relative "../lib/bag_courier"
+require_relative "../lib/bag_repository"
+require_relative "../lib/bag_validator"
+require_relative "../lib/config"
+require_relative "../lib/data_transfer"
+require_relative "../lib/dispatcher"
+require_relative "../lib/remote_client"
+require_relative "../lib/repository_data"
+require_relative "../lib/repository_package_repository"
+require_relative "../lib/status_event_repository"
+
+class APTrustDispatcherTest < SequelTestCase
+  def setup
+    settings = Config::SettingsConfig.new(
+      working_dir: "/prep",
+      export_dir: "/export",
+      remove_export: true,
+      dry_run: false,
+
+      # not used by Dispatchers
+      log_level: :debug,
+      object_size_limit: nil
+    )
+    repository = Config::RepositoryConfig.new(
+      name: "Some Repository",
+      description: "Bag containing an item from some repository"
+    )
+    target_client = RemoteClient::RemoteClientFactory.from_config(
+      type: :aptrust,
+      settings: Config::AptrustAwsRemoteConfig.new(
+        region: "us-east-1",
+        receiving_bucket: "aptrust.receiving.org.edu",
+        restore_bucket: "aptrust.restore.org.edu",
+        access_key_id: "some-key-id",
+        secret_access_key: "some-secret-key"
+      )
+    )
+
+    @package_identifier = "00001"
+    RepositoryPackageRepository::RepositoryPackageDatabaseRepository.new.create(
+      identifier: @package_identifier,
+      repository_name: repository.name,
+      updated_at: Time.now.utc
+    )
+
+    @dispatcher = Dispatcher::APTrustDispatcher.new(
+      settings: settings,
+      repository: repository,
+      target_client: target_client,
+      bag_repo: BagRepository::BagDatabaseRepository.new,
+      status_event_repo: StatusEventRepository::StatusEventDatabaseRepository.new
+    )
+  end
+
+  def test_dispatcher_setup
+    assert @dispatcher.respond_to?(:dispatch)
+    assert @dispatcher.bag_repo.is_a?(BagRepository::BagDatabaseRepository)
+    assert @dispatcher.status_event_repo.is_a?(
+      StatusEventRepository::StatusEventDatabaseRepository
+    )
+  end
+
+  def test_dispatch
+    courier = @dispatcher.dispatch(
+      object_metadata: RepositoryData::ObjectMetadata.new(
+        id: @package_identifier,
+        title: "Some title",
+        creator: "Some creator",
+        description: "Something something something"
+      ),
+      data_transfer: DataTransfer::RemoteClientDataTransfer.new(
+        remote_client: RemoteClient::FileSystemRemoteClient.new("/some/path"),
+        remote_path: "some_subdir"
+      ),
+      context: "some-context",
+      validator: InnerBagValidator.new("some-inner-bag-name"),
+      extra_bag_info_data: {something_extra: true}
+    )
+    assert courier.is_a?(BagCourier::BagCourier)
+  end
+end

--- a/test/test_dispatcher.rb
+++ b/test/test_dispatcher.rb
@@ -16,15 +16,11 @@ require_relative "../lib/status_event_repository"
 
 class APTrustDispatcherTest < SequelTestCase
   def setup
-    settings = Config::SettingsConfig.new(
+    workflow_settings = Config::WorkflowConfig.new(
       working_dir: "/prep",
       export_dir: "/export",
       remove_export: true,
-      dry_run: false,
-
-      # not used by Dispatchers
-      log_level: :debug,
-      object_size_limit: nil
+      dry_run: false
     )
     repository = Config::RepositoryConfig.new(
       name: "some-repo",
@@ -49,7 +45,7 @@ class APTrustDispatcherTest < SequelTestCase
     )
 
     @dispatcher = Dispatcher::APTrustDispatcher.new(
-      settings: settings,
+      settings: workflow_settings,
       repository: repository,
       context: "some-context",
       extra_bag_info_data: {"something_extra" => true},

--- a/test/test_dispatcher.rb
+++ b/test/test_dispatcher.rb
@@ -52,6 +52,7 @@ class APTrustDispatcherTest < SequelTestCase
       settings: settings,
       repository: repository,
       context: "some-context",
+      extra_bag_info_data: {"something_extra" => true},
       target_client: target_client,
       bag_repo: BagRepository::BagDatabaseRepository.new,
       status_event_repo: StatusEventRepository::StatusEventDatabaseRepository.new
@@ -72,8 +73,7 @@ class APTrustDispatcherTest < SequelTestCase
         remote_client: RemoteClient::FileSystemRemoteClient.new("/some/path"),
         remote_path: "some_subdir"
       ),
-      validator: InnerBagValidator.new("some-inner-bag-name"),
-      extra_bag_info_data: {"something_extra" => true}
+      validator: InnerBagValidator.new("some-inner-bag-name")
     )
   end
 


### PR DESCRIPTION
This PR aims to resolve DBAI-42.

To Do
- [x] Move `context` and `extra_bag_info` into `Dispatcher` constructor
- [x] Modify `DarkBlueJob` to make a `Dispatcher` instance for each Archivematica instance
- [x] Create `WorkflowConfig` to allow only passing variables needed by `Dispatcher`/`BagCourier`.
- [x] Add basic tests for `APTrustDispatcher` 