### PR TITLE
Use `Mock` for both `Registry` and `Gauge`

### DIFF
--- a/test/test_metrics_collector.rb
+++ b/test/test_metrics_collector.rb
@@ -3,7 +3,6 @@ require "minitest/pride"
 require "minitest/mock"
 
 require_relative "setup_db"
-require_relative "../db/database_schema"
 require_relative "../lib/bag_status"
 require_relative "../lib/bag_repository"
 require_relative "../lib/metrics_collector"
@@ -18,36 +17,45 @@ class DarkBlueMetricTest < Minitest::Test
     @status_event_repo = StatusEventRepository::StatusEventInMemoryRepository.new
     @push_gateway_url = "http://fake.pushgateway"
 
-    @metrics = DarkBlueMetrics::MetricsProvider.new(start_time: @start_time, end_time: @end_time, status_event_repo: @status_event_repo, push_gateway_url: @push_gateway_url)
-    @registry = Prometheus::Client::Registry.new
+    @registry = Minitest::Mock.new
     @gauge_mock = Minitest::Mock.new
-  end
 
-  def test_initialize
-    assert_equal @start_time, @metrics.instance_variable_get(:@start_time)
-    assert_equal @end_time, @metrics.instance_variable_get(:@end_time)
+    @metrics = DarkBlueMetrics::MetricsProvider.new(
+      start_time: @start_time,
+      end_time: @end_time,
+      status_event_repo: @status_event_repo,
+      push_gateway_url: @push_gateway_url,
+      registry: @registry
+    )
   end
 
   def test_set_last_successful_run
     expected_time = (@start_time.to_i * 1000)
-    @registry.stub(:gauge, @gauge_mock) do
-      actual_time = @metrics.set_last_successful_run
-      @gauge_mock.verify
-      assert_equal(expected_time, actual_time)
-    end
+    @registry.expect(
+      :gauge,
+      @gauge_mock,
+      [:dark_blue_last_successful_run],
+      docstring: "Timestamp of the last successful run of the cron job"
+    )
+    @gauge_mock.expect(:set, nil, [expected_time])
+    @metrics.set_last_successful_run
+    @gauge_mock.verify
   end
 
   def test_set_processing_duration
-    expect_duration = @end_time - @start_time
-    @registry.stub(:gauge, @gauge_mock) do
-      actual_duration = @metrics.set_processing_duration
-      @gauge_mock.verify
-      assert_equal(expect_duration, actual_duration)
-    end
+    expected_duration = 5
+    @registry.expect(
+      :gauge,
+      @gauge_mock,
+      [:dark_blue_processing_duration],
+      docstring: "Duration of processing in seconds for the cron job"
+    )
+    @gauge_mock.expect(:set, nil, [expected_duration])
+    @metrics.set_processing_duration
+    @gauge_mock.verify
   end
 
   def test_set_success_count
-    @status_event_repo.status_events.clear
     @bag_identifier_one = "repository.context-0001"
     @bag_identifier_two = "repository.context-0002"
     @deposited_at = Time.utc(2024, 3, 18)
@@ -64,17 +72,20 @@ class DarkBlueMetricTest < Minitest::Test
       timestamp: @deposited_at
     )
 
+    @registry.expect(
+      :gauge,
+      @gauge_mock,
+      [:dark_blue_success_count],
+      docstring: "Number of successful bag transfers"
+    )
     expected = 1
-    @registry.stub(:gauge, @gauge_mock) do
-      events_by_time = @metrics.get_latest_bag_events_by_time
-      actual = @metrics.set_success_count(events_by_time)
-      @gauge_mock.verify
-      assert_equal(expected, actual)
-    end
+    events_by_time = @metrics.get_latest_bag_events_by_time
+    @gauge_mock.expect(:set, nil, [expected])
+    @metrics.set_success_count(events_by_time)
+    @gauge_mock.verify
   end
 
   def test_set_failed_count
-    @status_event_repo.status_events.clear
     @bag_identifier_one = "repository.context-0001"
     @bag_identifier_two = "repository.context-0002"
     @deposited_at = Time.utc(2024, 3, 18)
@@ -91,16 +102,19 @@ class DarkBlueMetricTest < Minitest::Test
       timestamp: @deposited_at
     )
     expected = 1
-    @registry.stub(:gauge, @gauge_mock) do
-      events_by_time = @metrics.get_latest_bag_events_by_time
-      actual = @metrics.set_failed_count(events_by_time)
-      @gauge_mock.verify
-      assert_equal(expected, actual)
-    end
+    @registry.expect(
+      :gauge,
+      @gauge_mock,
+      [:dark_blue_failed_count],
+      docstring: "Number of failed bag transfers"
+    )
+    events_by_time = @metrics.get_latest_bag_events_by_time
+    @gauge_mock.expect(:set, nil, [expected])
+    @metrics.set_failed_count(events_by_time)
+    @gauge_mock.verify
   end
 
   def test_get_latest_bag_events_by_time
-    @status_event_repo.status_events.clear
     @bag_identifier_one = "repository.context-0001"
     @bag_identifier_two = "repository.context-0002"
     @deposited_at = Time.utc(2024, 3, 18)
@@ -121,7 +135,6 @@ class DarkBlueMetricTest < Minitest::Test
   end
 
   def test_get_success_count
-    @status_event_repo.status_events.clear
     @bag_identifier_one = "repository.context-0001"
     @bag_identifier_two = "repository.context-0002"
     @deposited_at = Time.utc(2024, 3, 18)
@@ -143,7 +156,6 @@ class DarkBlueMetricTest < Minitest::Test
   end
 
   def test_get_failure_count
-    @status_event_repo.status_events.clear
     @bag_identifier_one = "repository.context-0001"
     @bag_identifier_two = "repository.context-0002"
     @deposited_at = Time.utc(2024, 3, 18)
@@ -165,7 +177,6 @@ class DarkBlueMetricTest < Minitest::Test
   end
 
   def test_get_failed_bag_ids
-    @status_event_repo.status_events.clear
     @bag_identifier_one = "repository.context-0001"
     @bag_identifier_two = "repository.context-0002"
     @deposited_at = Time.utc(2024, 3, 18)
@@ -187,27 +198,23 @@ class DarkBlueMetricTest < Minitest::Test
   end
 
   def test_get_latest_bag_events_by_time_empty_array
-    @status_event_repo.status_events.clear
     actual_result = @metrics.get_latest_bag_events_by_time
     assert_equal [], actual_result
   end
 
   def test_get_success_count_nil
-    @status_event_repo.status_events.clear
     events_by_time = @metrics.get_latest_bag_events_by_time
     actual_result = @metrics.get_success_count(events_by_time)
     assert_equal 0, actual_result
   end
 
   def test_get_failure_count_nil
-    @status_event_repo.status_events.clear
     events_by_time = @metrics.get_latest_bag_events_by_time
     actual_result = @metrics.get_failure_count(events_by_time)
     assert_equal 0, actual_result
   end
 
   def test_get_failed_bag_ids_nil
-    @status_event_repo.status_events.clear
     events_by_time = @metrics.get_latest_bag_events_by_time
     actual_result = @metrics.get_failed_bag_ids(events_by_time)
     assert_equal [], actual_result

--- a/test/test_metrics_collector.rb
+++ b/test/test_metrics_collector.rb
@@ -17,7 +17,7 @@ class DarkBlueMetricTest < Minitest::Test
     @status_event_repo = StatusEventRepository::StatusEventInMemoryRepository.new
     @push_gateway_url = "http://fake.pushgateway"
 
-    @registry = Minitest::Mock.new
+    @registry_mock = Minitest::Mock.new
     @gauge_mock = Minitest::Mock.new
 
     @metrics = DarkBlueMetrics::MetricsProvider.new(
@@ -25,13 +25,13 @@ class DarkBlueMetricTest < Minitest::Test
       end_time: @end_time,
       status_event_repo: @status_event_repo,
       push_gateway_url: @push_gateway_url,
-      registry: @registry
+      registry: @registry_mock
     )
   end
 
   def test_set_last_successful_run
     expected_time = (@start_time.to_i * 1000)
-    @registry.expect(
+    @registry_mock.expect(
       :gauge,
       @gauge_mock,
       [:dark_blue_last_successful_run],
@@ -39,12 +39,13 @@ class DarkBlueMetricTest < Minitest::Test
     )
     @gauge_mock.expect(:set, nil, [expected_time])
     @metrics.set_last_successful_run
+    @registry_mock.verify
     @gauge_mock.verify
   end
 
   def test_set_processing_duration
     expected_duration = 5
-    @registry.expect(
+    @registry_mock.expect(
       :gauge,
       @gauge_mock,
       [:dark_blue_processing_duration],
@@ -52,6 +53,7 @@ class DarkBlueMetricTest < Minitest::Test
     )
     @gauge_mock.expect(:set, nil, [expected_duration])
     @metrics.set_processing_duration
+    @registry_mock.verify
     @gauge_mock.verify
   end
 
@@ -72,7 +74,7 @@ class DarkBlueMetricTest < Minitest::Test
       timestamp: @deposited_at
     )
 
-    @registry.expect(
+    @registry_mock.expect(
       :gauge,
       @gauge_mock,
       [:dark_blue_success_count],
@@ -82,6 +84,7 @@ class DarkBlueMetricTest < Minitest::Test
     events_by_time = @metrics.get_latest_bag_events_by_time
     @gauge_mock.expect(:set, nil, [expected])
     @metrics.set_success_count(events_by_time)
+    @registry_mock.verify
     @gauge_mock.verify
   end
 
@@ -102,7 +105,7 @@ class DarkBlueMetricTest < Minitest::Test
       timestamp: @deposited_at
     )
     expected = 1
-    @registry.expect(
+    @registry_mock.expect(
       :gauge,
       @gauge_mock,
       [:dark_blue_failed_count],
@@ -111,6 +114,7 @@ class DarkBlueMetricTest < Minitest::Test
     events_by_time = @metrics.get_latest_bag_events_by_time
     @gauge_mock.expect(:set, nil, [expected])
     @metrics.set_failed_count(events_by_time)
+    @registry_mock.verify
     @gauge_mock.verify
   end
 


### PR DESCRIPTION
Here's the result of some experimentation with your test cases. I think this is nice because it allows us to check our usage of `registry.gauge`, which we couldn't do before. I've incorporated some other changes -- some of which I flagged already in comments. We can discuss tomorrow.