### PR TITLE
Add build-release GitHub Action (DBAI-56)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,16 @@
+---
+name: Build release
+
+on:
+  release:
+    types: [ released ]
+
+jobs:
+  build-production:
+    name: Build production ${{ github.event.release.tag_name }}
+    uses: mlibrary/platform-engineering-workflows/.github/workflows/build-production.yml@v1
+    with:
+      image_name: ${{ vars.IMAGE_NAME }}
+      tag: ${{ github.event.release.tag_name }}
+      dockerfile: Dockerfile
+    secrets: inherit

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -10,7 +10,7 @@ jobs:
     name: Build production ${{ github.event.release.tag_name }}
     uses: mlibrary/platform-engineering-workflows/.github/workflows/build-production.yml@v1
     with:
-      image_name: ${{ vars.IMAGE_NAME }}
+      image_name: bag-courier
       tag: ${{ github.event.release.tag_name }}
       dockerfile: Dockerfile
     secrets: inherit


### PR DESCRIPTION
This PR aims to resolve DBAI-56.

It uses [this action](https://github.com/mlibrary/catalog-browse-indexing/blob/main/.github/workflows/build-deploy-on-release.yaml) as a model and makes a couple modifications.