### PR TITLE
Tweak path handling to support `FileSystemRemoteClient` and `SftpRemoteClient`

### DIFF
--- a/lib/archivematica.rb
+++ b/lib/archivematica.rb
@@ -71,10 +71,14 @@ module Archivematica
       results
     end
 
+    def normalize_path(path)
+      path.delete_prefix("/")
+    end
+
     def create_package(package_data)
       Package.new(
         uuid: package_data["uuid"],
-        path: package_data["current_full_path"],
+        path: normalize_path(package_data["current_full_path"]),
         size: package_data["size"],
         stored_date: package_data["stored_date"]
       )

--- a/lib/archivematica.rb
+++ b/lib/archivematica.rb
@@ -74,6 +74,7 @@ module Archivematica
     def normalize_path(path)
       path.delete_prefix("/")
     end
+    private :normalize_path
 
     def create_package(package_data)
       Package.new(

--- a/lib/remote_client.rb
+++ b/lib/remote_client.rb
@@ -239,6 +239,14 @@ module RemoteClient
       @host = host
     end
 
+    def make_absolute(path)
+      new_path = path
+      if !new_path.start_with?("/")
+        new_path = "/" + new_path
+      end
+      new_path
+    end
+
     def self.from_config(user:, host:, key_path:)
       SFTP.configure do |config|
         config.host = host
@@ -256,23 +264,31 @@ module RemoteClient
       PathValidator.ensure_present(local_file_path)
       if !remote_path.nil?
         PathValidator.ensure_not_empty(remote_path)
+        PathValidator.ensure_no_traversal(remote_path)
+        new_remote_path = make_absolute(remote_path)
+      else
+        new_remote_path = "/"
       end
 
-      @client.put(local_file_path, remote_path || ".")
+      @client.put(local_file_path, new_remote_path)
     end
 
     def retrieve_file(remote_file_path:, local_dir_path:)
       PathValidator.ensure_present(remote_file_path)
+      PathValidator.ensure_no_traversal(remote_file_path)
       PathValidator.ensure_present(local_dir_path)
 
-      @client.get(remote_file_path, local_dir_path)
+      new_remote_file_path = make_absolute(remote_file_path)
+      @client.get(new_remote_file_path, local_dir_path)
     end
 
     def retrieve_from_path(local_path:, remote_path:)
       PathValidator.ensure_present(local_path)
       PathValidator.ensure_present(remote_path)
+      PathValidator.ensure_no_traversal(remote_path)
 
-      @client.get_r(remote_path, local_path)
+      new_remote_path = make_absolute(remote_path)
+      @client.get_r(new_remote_path, local_path)
     end
   end
 

--- a/lib/remote_client.rb
+++ b/lib/remote_client.rb
@@ -246,6 +246,7 @@ module RemoteClient
       end
       new_path
     end
+    private :make_absolute
 
     def self.from_config(user:, host:, key_path:)
       SFTP.configure do |config|

--- a/test/test_archivematica.rb
+++ b/test/test_archivematica.rb
@@ -74,7 +74,6 @@ class ArchivematicaAPITest < Minitest::Test
       )
     ]
 
-
     @mock_backend = Minitest::Mock.new
     @mocked_api = ArchivematicaAPI.new(
       api_backend: @mock_backend

--- a/test/test_archivematica.rb
+++ b/test/test_archivematica.rb
@@ -53,6 +53,28 @@ class ArchivematicaAPITest < Minitest::Test
       }
     ]
 
+    @expected_packages = [
+      Package.new(
+        uuid: "9e7bbf35-9e31-4679-9228-e132ddcf34ea",
+        path: "storage/9e7b/bf35/9e31/4679/9228/e132/ddcf/34ea/identifier-one-9e7bbf35-9e31-4679-9228-e132ddcf34ea",
+        size: 1000,
+        stored_date: "2024-01-17T00:00:00.000000"
+      ),
+      Package.new(
+        uuid: "590a9015-a5ef-47af-b0da-276a88ecd543",
+        path: "storage/590a/9015/a5ef/47af/b0da/276a/88ec/d543/identifier-two-590a9015-a5ef-47af-b0da-276a88ecd543",
+        size: 300000,
+        stored_date: "2024-01-16T00:00:00.000000"
+      ),
+      Package.new(
+        uuid: "4fb38e65-a972-434e-a32c-d668a122514a",
+        path: "storage/4fb3/8e65/a972/434e/a32c/d668/a122/514a/identifier-three-4fb38e65-a972-434e-a32c-d668a122514a",
+        size: 5000000,
+        stored_date: "2024-01-13T00:00:00.000000"
+      )
+    ]
+
+
     @mock_backend = Minitest::Mock.new
     @mocked_api = ArchivematicaAPI.new(
       api_backend: @mock_backend
@@ -140,7 +162,7 @@ class ArchivematicaAPITest < Minitest::Test
     @api.stub :get_objects_from_pages, args_checker do
       packages = @api.get_packages(location_uuid: @location_uuid)
       assert packages.all? { |p| p.is_a?(Archivematica::Package) }
-      assert_equal(@package_data.map { |p| p["uuid"] }, packages.map { |p| p.uuid })
+      assert_equal(packages, @expected_packages)
     end
   end
 
@@ -161,7 +183,7 @@ class ArchivematicaAPITest < Minitest::Test
     @api.stub :get_objects_from_pages, args_checker do
       packages = @api.get_packages(location_uuid: @location_uuid, stored_date: time_filter)
       assert packages.all? { |p| p.is_a?(Archivematica::Package) }
-      assert_equal(@package_data.map { |p| p["uuid"] }, packages.map { |p| p.uuid })
+      assert_equal(packages, @expected_packages)
     end
   end
 
@@ -170,7 +192,7 @@ class ArchivematicaAPITest < Minitest::Test
 
     expected = Package.new(
       uuid: "9e7bbf35-9e31-4679-9228-e132ddcf34ea",
-      path: "/storage/9e7b/bf35/9e31/4679/9228/e132/ddcf/34ea/identifier-one-9e7bbf35-9e31-4679-9228-e132ddcf34ea",
+      path: "storage/9e7b/bf35/9e31/4679/9228/e132/ddcf/34ea/identifier-one-9e7bbf35-9e31-4679-9228-e132ddcf34ea",
       size: 1000,
       stored_date: "2024-01-17T00:00:00.000000"
     )
@@ -200,13 +222,13 @@ class ArchivematicaServiceTest < Minitest::Test
 
     @first_package = Package.new(
       uuid: "0948e2ae-eb24-4984-a71b-43bc440534d0",
-      path: "/storage/0948/e2ae/eb24/4984/a71b/43bc/4405/34d0/identifier-one-0948e2ae-eb24-4984-a71b-43bc440534d0",
+      path: "storage/0948/e2ae/eb24/4984/a71b/43bc/4405/34d0/identifier-one-0948e2ae-eb24-4984-a71b-43bc440534d0",
       size: 200000,
       stored_date: "2024-02-18T00:00:00.000000"
     )
     @second_package = Package.new(
       uuid: "0baa468e-dd42-49ff-ba90-5dedc30c8541",
-      path: "/storage/0baa/468e/dd42/49ff/ba90/5ded/c30c/8541/identifier-two-0baa468e-dd42-49ff-ba90-5dedc30c8541",
+      path: "storage/0baa/468e/dd42/49ff/ba90/5ded/c30c/8541/identifier-two-0baa468e-dd42-49ff-ba90-5dedc30c8541",
       size: 500000000,
       stored_date: "2024-02-19T00:00:00.000000"
     )

--- a/test/test_archivematica.rb
+++ b/test/test_archivematica.rb
@@ -145,7 +145,7 @@ class ArchivematicaAPITest < Minitest::Test
       "limit" => 1
     })
     @mock_backend.verify
-    assert_equal objects, @package_data
+    assert_equal @package_data, objects
   end
 
   def test_get_packages_with_no_stored_date
@@ -162,7 +162,7 @@ class ArchivematicaAPITest < Minitest::Test
     @api.stub :get_objects_from_pages, args_checker do
       packages = @api.get_packages(location_uuid: @location_uuid)
       assert packages.all? { |p| p.is_a?(Archivematica::Package) }
-      assert_equal(packages, @expected_packages)
+      assert_equal(@expected_packages, packages)
     end
   end
 
@@ -183,7 +183,7 @@ class ArchivematicaAPITest < Minitest::Test
     @api.stub :get_objects_from_pages, args_checker do
       packages = @api.get_packages(location_uuid: @location_uuid, stored_date: time_filter)
       assert packages.all? { |p| p.is_a?(Archivematica::Package) }
-      assert_equal(packages, @expected_packages)
+      assert_equal(@expected_packages, packages)
     end
   end
 

--- a/test/test_remote_client.rb
+++ b/test/test_remote_client.rb
@@ -139,7 +139,7 @@ class SftpRemoteClientTest < Minitest::Test
 
   def test_send_file
     local_path = File.join(@local_dir, "file.txt")
-    @mock_sftp_client.expect(:put, "some string output", [local_path, "special"])
+    @mock_sftp_client.expect(:put, "some string output", [local_path, "/special"])
     @remote_client_with_mock.send_file(
       local_file_path: local_path, remote_path: "special"
     )
@@ -148,14 +148,14 @@ class SftpRemoteClientTest < Minitest::Test
 
   def test_send_file_to_root
     local_path = File.join(@local_dir, "file.txt")
-    @mock_sftp_client.expect(:put, "some string output", [local_path, "."])
+    @mock_sftp_client.expect(:put, "some string output", [local_path, "/"])
     @remote_client_with_mock.send_file(local_file_path: local_path)
     @mock_sftp_client.verify
   end
 
   def test_retrieve_file
     remote_path = File.join("special", "file.txt")
-    @mock_sftp_client.expect(:get, "some string output", [remote_path, @local_dir])
+    @mock_sftp_client.expect(:get, "some string output", ["/" + remote_path, @local_dir])
     @remote_client_with_mock.retrieve_file(
       remote_file_path: remote_path, local_dir_path: @local_dir
     )
@@ -163,7 +163,7 @@ class SftpRemoteClientTest < Minitest::Test
   end
 
   def test_retrieve_from_path
-    remote_path = File.join("special")
+    remote_path = File.join("/special")
     @mock_sftp_client.expect(:get_r, "some string output", [remote_path, @local_dir])
     @remote_client_with_mock.retrieve_from_path(
       remote_path: remote_path, local_path: @local_dir


### PR DESCRIPTION
This PR modifies path handling in the application to fully support usage of both `FileSystemRemoteClient` and `SftpRemoteClient`. It does this by 1) stripping the leading slash in paths coming from the Archivematica REST API and 2) adding back the slash (or making absolute) remote paths going into `SftpRemoteClient`. The PR also improves unit tests of the `ArchivematicaAPI` by doing a full equality check of `Package` instances.